### PR TITLE
enhancement: don't panic if profile is nil on GetCurrentProfile

### DIFF
--- a/shared/fileconfiguration/fileconfiguration.go
+++ b/shared/fileconfiguration/fileconfiguration.go
@@ -241,6 +241,10 @@ func (f *FileConfig) GetOverride(productName, location string) *Endpoint {
 // if the current profile is not set, it returns nil
 // if the current profile is set and found in the loaded configuration, it returns the profile
 func (f *FileConfig) GetCurrentProfile() *Profile {
+	if f == nil {
+		return nil
+	}
+
 	currentProfile := os.Getenv(shared.IonosCurrentProfileEnvVar)
 	if currentProfile == "" {
 		currentProfile = f.CurrentProfile


### PR DESCRIPTION
 don't panic if profile is nil on GetCurrentProfile calls, instead return nil.