### PR TITLE
Fix typo in token authentication example

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ Save the generated token and use it to authenticate:
 
     func TokenAuthExample() error {
         //note: to use NewConfigurationFromEnv(), you need to previously set IONOS_TOKEN as env variables
-        authClient := shared.NewAPIClient(authApi.NewConfigurationFromEnv())
+        authClient := shared.NewAPIClient(auth.NewConfigurationFromEnv())
         apiClient := compute.NewAPIClient(cfg)
         datacenters, _, err := apiClient.DataCentersApi.DatacentersGet(context.Background()).Depth(1).Execute()
         if err != nil {

--- a/README.md
+++ b/README.md
@@ -160,25 +160,24 @@ export IONOS_TOKEN="insert_here_token_saved_from_generate_command"
 ```
 Save the generated token and use it to authenticate:
 ```golang
-    import (
-        "context"
-        "fmt"
-        "log"
-		
-        "github.com/ionos-cloud/sdk-go-bundle/shared"
-        "github.com/ionos-cloud/sdk-go-bundle/products/compute"
-    )
+      import (
+          "context"
+          "fmt"
 
-    func TokenAuthExample() error {
-        //note: to use NewConfigurationFromEnv(), you need to previously set IONOS_TOKEN as env variables
-        authClient := shared.NewAPIClient(auth.NewConfigurationFromEnv())
-        apiClient := compute.NewAPIClient(cfg)
-        datacenters, _, err := apiClient.DataCentersApi.DatacentersGet(context.Background()).Depth(1).Execute()
-        if err != nil {
-            return fmt.Errorf("error retrieving datacenters (%w)", err)
-        }
-        return nil
-    }
+          "github.com/ionos-cloud/sdk-go-bundle/shared"
+          "github.com/ionos-cloud/sdk-go-bundle/products/compute"
+      )
+
+      func TokenAuthExample() error {
+          //note: to use NewConfigurationFromEnv(), you need to previously set IONOS_TOKEN as env variables
+          cfg := shared.NewConfigurationFromEnv()
+          apiClient := compute.NewAPIClient(cfg)
+          datacenters, _, err := apiClient.DataCentersApi.DatacentersGet(context.Background()).Depth(1).Execute()
+          if err != nil {
+              return fmt.Errorf("error retrieving datacenters (%w)", err)
+          }
+          return nil
+      }
 ``` 
 
 ## Config File Usage


### PR DESCRIPTION
 ## Description
   This PR fixes a typo in the token authentication code example.
   
   ## Changes Made
   - Changed `authApi.NewConfigurationFromEnv()` to `auth.NewConfigurationFromEnv()`
   - This matches the actual imported package name `auth`
   
   ## Why This Change?
   The code example was using `authApi` which is not defined, when it should use `auth` which is the imported package.