### PR TITLE
feat: interfaces, resolve resources by name, tests

### DIFF
--- a/.github/workflows/shared-tests.yml
+++ b/.github/workflows/shared-tests.yml
@@ -1,0 +1,32 @@
+name: Shared Library Tests
+on:
+  workflow_dispatch:
+  push:
+    branches: [v2]
+    paths:
+      - 'shared/**'
+  pull_request:
+    paths:
+      - 'shared/**'
+
+jobs:
+  test:
+    name: Test shared/
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: shared/go.mod
+
+      - name: Run tests
+        working-directory: shared
+        run: go test -v -race -coverprofile=coverage.out ./...
+
+      - name: Upload coverage
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: shared-coverage
+          path: shared/coverage.out

--- a/shared/interfaces.go
+++ b/shared/interfaces.go
@@ -1,0 +1,66 @@
+package shared
+
+// Identifiable is satisfied by any SDK model type that exposes a string ID.
+// All *Read types across SDK products (dns.ZoneRead, compute.Datacenter,
+// vpn.WireguardGatewayRead, etc.) implement this interface via their
+// generated GetId() method.
+type Identifiable interface {
+	GetId() string
+}
+
+// HasHref is satisfied by any SDK model type that exposes an href link.
+type HasHref interface {
+	GetHref() string
+}
+
+// Resource combines Identifiable and HasHref — the two universally
+// consistent accessor methods across all SDK product model types.
+type Resource interface {
+	Identifiable
+	HasHref
+}
+
+// Listable is satisfied by SDK list response types that expose their
+// items via GetItems(). Most generated list types (dns.ZoneReadList,
+// vpn.IPSecGatewayReadList, compute.Datacenters, etc.) satisfy this.
+type Listable[T any] interface {
+	GetItems() []T
+}
+
+// HasProperties is satisfied by SDK model types that wrap a properties
+// sub-object (e.g., dns.ZoneRead exposes GetProperties() dns.Zone).
+type HasProperties[P any] interface {
+	GetProperties() P
+}
+
+// ExtractIDs returns the IDs from a slice of Identifiable items.
+func ExtractIDs[T Identifiable](items []T) []string {
+	ids := make([]string, len(items))
+	for i, item := range items {
+		ids[i] = item.GetId()
+	}
+	return ids
+}
+
+// FindByID returns the first item matching the given ID, and true if found.
+func FindByID[T Identifiable](items []T, id string) (T, bool) {
+	for _, item := range items {
+		if item.GetId() == id {
+			return item, true
+		}
+	}
+	var zero T
+	return zero, false
+}
+
+// ListItems extracts items from a Listable response. This is a convenience
+// wrapper useful in generic contexts where the list type is a type parameter.
+func ListItems[T any, L Listable[T]](list L) []T {
+	return list.GetItems()
+}
+
+// Properties extracts the properties from a HasProperties type. Useful in
+// generic contexts where both the model and properties types are parameters.
+func Properties[P any, T HasProperties[P]](item T) P {
+	return item.GetProperties()
+}

--- a/shared/interfaces.go
+++ b/shared/interfaces.go
@@ -64,14 +64,3 @@ func FindByID[T any, PT interface {
 	return nil, false
 }
 
-// ListItems extracts items from a Listable response. This is a convenience
-// wrapper useful in generic contexts where the list type is a type parameter.
-func ListItems[T any, L Listable[T]](list L) []T {
-	return list.GetItems()
-}
-
-// Properties extracts the properties from a HasProperties type. Useful in
-// generic contexts where both the model and properties types are parameters.
-func Properties[P any, T HasProperties[P]](item T) P {
-	return item.GetProperties()
-}

--- a/shared/interfaces.go
+++ b/shared/interfaces.go
@@ -33,24 +33,35 @@ type HasProperties[P any] interface {
 	GetProperties() P
 }
 
-// ExtractIDs returns the IDs from a slice of Identifiable items.
-func ExtractIDs[T Identifiable](items []T) []string {
+// ExtractIDs returns the IDs from a slice of value-type items whose pointer
+// type satisfies Identifiable. Works directly with SDK list results:
+//
+//	ids := shared.ExtractIDs(list.GetItems())
+func ExtractIDs[T any, PT interface {
+	*T
+	Identifiable
+}](items []T) []string {
 	ids := make([]string, len(items))
-	for i, item := range items {
-		ids[i] = item.GetId()
+	for i := range items {
+		ids[i] = PT(&items[i]).GetId()
 	}
 	return ids
 }
 
-// FindByID returns the first item matching the given ID, and true if found.
-func FindByID[T Identifiable](items []T, id string) (T, bool) {
-	for _, item := range items {
-		if item.GetId() == id {
-			return item, true
+// FindByID returns a pointer to the first item matching the given ID, and
+// true if found. Works directly with SDK list results:
+//
+//	zone, ok := shared.FindByID(list.GetItems(), id)
+func FindByID[T any, PT interface {
+	*T
+	Identifiable
+}](items []T, id string) (*T, bool) {
+	for i := range items {
+		if PT(&items[i]).GetId() == id {
+			return &items[i], true
 		}
 	}
-	var zero T
-	return zero, false
+	return nil, false
 }
 
 // ListItems extracts items from a Listable response. This is a convenience

--- a/shared/interfaces_example_test.go
+++ b/shared/interfaces_example_test.go
@@ -8,8 +8,8 @@ import (
 
 // ──────────────────────────────────────────────────────────────────────────────
 // Mock types that mirror the generated SDK model shape (e.g. dns.ZoneRead,
-// dns.Zone, dns.ZoneReadList). All generated SDK types follow this exact
-// pattern: pointer receivers, value-typed Items slices, nested Properties.
+// dns.Zone, dns.ZoneReadList). All generated SDK types use pointer receivers
+// and value-typed Items slices — these mocks follow the same pattern.
 // ──────────────────────────────────────────────────────────────────────────────
 
 // Zone mirrors a properties type like dns.Zone.
@@ -17,99 +17,41 @@ type Zone struct {
 	ZoneName string
 }
 
-func (o *Zone) GetZoneName() string {
-	if o == nil {
-		return ""
-	}
-	return o.ZoneName
-}
+func (o *Zone) GetZoneName() string { return o.ZoneName }
 
 // ZoneRead mirrors a read-model type like dns.ZoneRead.
-// Pointer receivers — exactly like the generated code.
 type ZoneRead struct {
 	Id         string
 	Href       string
 	Properties Zone
 }
 
-func (o *ZoneRead) GetId() string {
-	if o == nil {
-		return ""
-	}
-	return o.Id
-}
-
-func (o *ZoneRead) GetHref() string {
-	if o == nil {
-		return ""
-	}
-	return o.Href
-}
-
-func (o *ZoneRead) GetProperties() Zone {
-	if o == nil {
-		return Zone{}
-	}
-	return o.Properties
-}
+func (o *ZoneRead) GetId() string         { return o.Id }
+func (o *ZoneRead) GetHref() string       { return o.Href }
+func (o *ZoneRead) GetProperties() Zone   { return o.Properties }
 
 // ZoneReadList mirrors a list-response type like dns.ZoneReadList.
-// GetItems() returns []ZoneRead (values, not pointers) — exactly like
-// the generated code.
 type ZoneReadList struct {
 	Items []ZoneRead
 }
 
-func (o *ZoneReadList) GetItems() []ZoneRead {
-	if o == nil {
-		return nil
-	}
-	return o.Items
-}
-
-// Record mirrors a properties type like dns.Record.
-type Record struct {
-	Name    string
-	Type    string
-	Content string
-}
-
-func (o *Record) GetName() string {
-	if o == nil {
-		return ""
-	}
-	return o.Name
-}
+func (o *ZoneReadList) GetItems() []ZoneRead { return o.Items }
 
 // RecordRead mirrors a read-model type like dns.RecordRead.
-// Same pattern as ZoneRead: pointer receivers, same interface shape.
 type RecordRead struct {
-	Id         string
-	Href       string
-	Properties Record
+	Id   string
+	Href string
 }
 
-func (o *RecordRead) GetId() string {
-	if o == nil {
-		return ""
-	}
-	return o.Id
-}
-
-func (o *RecordRead) GetHref() string {
-	if o == nil {
-		return ""
-	}
-	return o.Href
-}
+func (o *RecordRead) GetId() string   { return o.Id }
+func (o *RecordRead) GetHref() string { return o.Href }
 
 // ──────────────────────────────────────────────────────────────────────────────
 // Examples — these appear in godoc and are executed by `go test`.
 // ──────────────────────────────────────────────────────────────────────────────
 
 func ExampleExtractIDs() {
-	// Simulate an API list response:
-	//   list, _, err := client.ZonesApi.ZonesGet(ctx).Execute()
+	// Simulate: list, _, err := client.ZonesApi.ZonesGet(ctx).Execute()
 	list := &ZoneReadList{
 		Items: []ZoneRead{
 			{Id: "aaa-111", Href: "/zones/aaa-111", Properties: Zone{ZoneName: "example.com"}},
@@ -125,8 +67,7 @@ func ExampleExtractIDs() {
 }
 
 func ExampleFindByID() {
-	// Simulate an API list response:
-	//   list, _, err := client.ZonesApi.ZonesGet(ctx).Execute()
+	// Simulate: list, _, err := client.ZonesApi.ZonesGet(ctx).Execute()
 	list := &ZoneReadList{
 		Items: []ZoneRead{
 			{Id: "aaa-111", Properties: Zone{ZoneName: "example.com"}},
@@ -143,41 +84,10 @@ func ExampleFindByID() {
 	// Output: example.org
 }
 
-func ExampleListItems() {
-	// Simulate an API list response:
-	//   list, _, err := client.ZonesApi.ZonesGet(ctx).Execute()
-	list := &ZoneReadList{
-		Items: []ZoneRead{
-			{Id: "aaa-111", Properties: Zone{ZoneName: "example.com"}},
-			{Id: "bbb-222", Properties: Zone{ZoneName: "example.org"}},
-		},
-	}
-
-	// ListItems is useful in generic contexts where the list type is a
-	// type parameter. For direct use, list.GetItems() works just as well.
-	items := shared.ListItems[ZoneRead](list)
-	fmt.Println(len(items))
-	// Output: 2
-}
-
-func ExampleProperties() {
-	zone := &ZoneRead{
-		Id:         "aaa-111",
-		Properties: Zone{ZoneName: "example.com"},
-	}
-
-	// Properties is useful in generic contexts where both the model and
-	// properties types are type parameters.
-	props := shared.Properties[Zone](zone)
-	fmt.Println(props.GetZoneName())
-	// Output: example.com
-}
-
-// Example_interfaces demonstrates that different SDK types (zones, records,
+// ExampleResource demonstrates that different SDK types (zones, records,
 // or any other product) can be combined into a single collection through the
 // shared interfaces and operated on uniformly.
-func Example_interfaces() {
-	// Simulate fetching zones and records from different API calls.
+func ExampleResource() {
 	zones := []ZoneRead{
 		{Id: "zone-aaa", Href: "/zones/zone-aaa"},
 		{Id: "zone-bbb", Href: "/zones/zone-bbb"},

--- a/shared/interfaces_example_test.go
+++ b/shared/interfaces_example_test.go
@@ -1,0 +1,210 @@
+package shared_test
+
+import (
+	"fmt"
+
+	"github.com/ionos-cloud/sdk-go-bundle/shared"
+)
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Mock types that mirror the generated SDK model shape (e.g. dns.ZoneRead,
+// dns.Zone, dns.ZoneReadList). All generated SDK types follow this exact
+// pattern: pointer receivers, value-typed Items slices, nested Properties.
+// ──────────────────────────────────────────────────────────────────────────────
+
+// Zone mirrors a properties type like dns.Zone.
+type Zone struct {
+	ZoneName string
+}
+
+func (o *Zone) GetZoneName() string {
+	if o == nil {
+		return ""
+	}
+	return o.ZoneName
+}
+
+// ZoneRead mirrors a read-model type like dns.ZoneRead.
+// Pointer receivers — exactly like the generated code.
+type ZoneRead struct {
+	Id         string
+	Href       string
+	Properties Zone
+}
+
+func (o *ZoneRead) GetId() string {
+	if o == nil {
+		return ""
+	}
+	return o.Id
+}
+
+func (o *ZoneRead) GetHref() string {
+	if o == nil {
+		return ""
+	}
+	return o.Href
+}
+
+func (o *ZoneRead) GetProperties() Zone {
+	if o == nil {
+		return Zone{}
+	}
+	return o.Properties
+}
+
+// ZoneReadList mirrors a list-response type like dns.ZoneReadList.
+// GetItems() returns []ZoneRead (values, not pointers) — exactly like
+// the generated code.
+type ZoneReadList struct {
+	Items []ZoneRead
+}
+
+func (o *ZoneReadList) GetItems() []ZoneRead {
+	if o == nil {
+		return nil
+	}
+	return o.Items
+}
+
+// Record mirrors a properties type like dns.Record.
+type Record struct {
+	Name    string
+	Type    string
+	Content string
+}
+
+func (o *Record) GetName() string {
+	if o == nil {
+		return ""
+	}
+	return o.Name
+}
+
+// RecordRead mirrors a read-model type like dns.RecordRead.
+// Same pattern as ZoneRead: pointer receivers, same interface shape.
+type RecordRead struct {
+	Id         string
+	Href       string
+	Properties Record
+}
+
+func (o *RecordRead) GetId() string {
+	if o == nil {
+		return ""
+	}
+	return o.Id
+}
+
+func (o *RecordRead) GetHref() string {
+	if o == nil {
+		return ""
+	}
+	return o.Href
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Examples — these appear in godoc and are executed by `go test`.
+// ──────────────────────────────────────────────────────────────────────────────
+
+func ExampleExtractIDs() {
+	// Simulate an API list response:
+	//   list, _, err := client.ZonesApi.ZonesGet(ctx).Execute()
+	list := &ZoneReadList{
+		Items: []ZoneRead{
+			{Id: "aaa-111", Href: "/zones/aaa-111", Properties: Zone{ZoneName: "example.com"}},
+			{Id: "bbb-222", Href: "/zones/bbb-222", Properties: Zone{ZoneName: "example.org"}},
+			{Id: "ccc-333", Href: "/zones/ccc-333", Properties: Zone{ZoneName: "example.net"}},
+		},
+	}
+
+	// Works directly with GetItems() — no []T to []*T conversion needed.
+	ids := shared.ExtractIDs(list.GetItems())
+	fmt.Println(ids)
+	// Output: [aaa-111 bbb-222 ccc-333]
+}
+
+func ExampleFindByID() {
+	// Simulate an API list response:
+	//   list, _, err := client.ZonesApi.ZonesGet(ctx).Execute()
+	list := &ZoneReadList{
+		Items: []ZoneRead{
+			{Id: "aaa-111", Properties: Zone{ZoneName: "example.com"}},
+			{Id: "bbb-222", Properties: Zone{ZoneName: "example.org"}},
+		},
+	}
+
+	// Returns a *ZoneRead pointer into the original slice.
+	zone, ok := shared.FindByID(list.GetItems(), "bbb-222")
+	if ok {
+		props := zone.GetProperties()
+		fmt.Println(props.GetZoneName())
+	}
+	// Output: example.org
+}
+
+func ExampleListItems() {
+	// Simulate an API list response:
+	//   list, _, err := client.ZonesApi.ZonesGet(ctx).Execute()
+	list := &ZoneReadList{
+		Items: []ZoneRead{
+			{Id: "aaa-111", Properties: Zone{ZoneName: "example.com"}},
+			{Id: "bbb-222", Properties: Zone{ZoneName: "example.org"}},
+		},
+	}
+
+	// ListItems is useful in generic contexts where the list type is a
+	// type parameter. For direct use, list.GetItems() works just as well.
+	items := shared.ListItems[ZoneRead](list)
+	fmt.Println(len(items))
+	// Output: 2
+}
+
+func ExampleProperties() {
+	zone := &ZoneRead{
+		Id:         "aaa-111",
+		Properties: Zone{ZoneName: "example.com"},
+	}
+
+	// Properties is useful in generic contexts where both the model and
+	// properties types are type parameters.
+	props := shared.Properties[Zone](zone)
+	fmt.Println(props.GetZoneName())
+	// Output: example.com
+}
+
+// Example_interfaces demonstrates that different SDK types (zones, records,
+// or any other product) can be combined into a single collection through the
+// shared interfaces and operated on uniformly.
+func Example_interfaces() {
+	// Simulate fetching zones and records from different API calls.
+	zones := []ZoneRead{
+		{Id: "zone-aaa", Href: "/zones/zone-aaa"},
+		{Id: "zone-bbb", Href: "/zones/zone-bbb"},
+	}
+	records := []RecordRead{
+		{Id: "rec-111", Href: "/records/rec-111"},
+		{Id: "rec-222", Href: "/records/rec-222"},
+		{Id: "rec-333", Href: "/records/rec-333"},
+	}
+
+	// Both *ZoneRead and *RecordRead satisfy shared.Resource (GetId + GetHref),
+	// so they can be combined into a single slice and operated on uniformly.
+	var all []shared.Resource
+	for i := range zones {
+		all = append(all, &zones[i])
+	}
+	for i := range records {
+		all = append(all, &records[i])
+	}
+
+	for _, r := range all {
+		fmt.Printf("%s -> %s\n", r.GetId(), r.GetHref())
+	}
+	// Output:
+	// zone-aaa -> /zones/zone-aaa
+	// zone-bbb -> /zones/zone-bbb
+	// rec-111 -> /records/rec-111
+	// rec-222 -> /records/rec-222
+	// rec-333 -> /records/rec-333
+}

--- a/shared/interfaces_test.go
+++ b/shared/interfaces_test.go
@@ -16,26 +16,11 @@ type ptrMockResource struct {
 
 func (m *ptrMockResource) GetId() string   { return m.id }
 func (m *ptrMockResource) GetHref() string { return m.href }
-func (m *ptrMockResource) GetProperties() mockProperties {
-	return mockProperties{Name: m.name}
-}
-
-type mockProperties struct {
-	Name string
-}
-
-type mockList struct {
-	items []ptrMockResource
-}
-
-func (l mockList) GetItems() []ptrMockResource { return l.items }
 
 // Compile-time interface satisfaction checks (pointer receivers — matches real SDKs)
 var _ Identifiable = &ptrMockResource{}
 var _ HasHref = &ptrMockResource{}
 var _ Resource = &ptrMockResource{}
-var _ Listable[ptrMockResource] = mockList{}
-var _ HasProperties[mockProperties] = &ptrMockResource{}
 
 func TestExtractIDs(t *testing.T) {
 	items := []ptrMockResource{
@@ -87,22 +72,4 @@ func TestFindByIDReturnsPointerIntoSlice(t *testing.T) {
 	// Mutating via returned pointer should modify the original slice
 	item.name = "mutated"
 	assert.Equal(t, "mutated", items[0].name)
-}
-
-func TestListItems(t *testing.T) {
-	list := mockList{
-		items: []ptrMockResource{
-			{id: "aaa-111"},
-			{id: "bbb-222"},
-		},
-	}
-	items := ListItems(list)
-	assert.Len(t, items, 2)
-	assert.Equal(t, "aaa-111", (*ptrMockResource)(&items[0]).GetId())
-}
-
-func TestProperties(t *testing.T) {
-	r := &ptrMockResource{id: "aaa-111", name: "test-zone"}
-	props := Properties(r)
-	assert.Equal(t, "test-zone", props.Name)
 }

--- a/shared/interfaces_test.go
+++ b/shared/interfaces_test.go
@@ -1,0 +1,96 @@
+package shared
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// mockResource is a minimal type satisfying Resource, Listable, and HasProperties
+// for testing. It mirrors the shape of generated SDK *Read types.
+type mockResource struct {
+	id   string
+	href string
+	typ  string
+	name string
+}
+
+func (m mockResource) GetId() string   { return m.id }
+func (m mockResource) GetHref() string { return m.href }
+func (m mockResource) GetType() string { return m.typ }
+func (m mockResource) GetProperties() mockProperties {
+	return mockProperties{Name: m.name}
+}
+
+type mockProperties struct {
+	Name string
+}
+
+type mockList struct {
+	items []mockResource
+}
+
+func (l mockList) GetItems() []mockResource { return l.items }
+
+// Compile-time interface satisfaction checks
+var _ Identifiable = mockResource{}
+var _ HasHref = mockResource{}
+var _ Resource = mockResource{}
+var _ Listable[mockResource] = mockList{}
+var _ HasProperties[mockProperties] = mockResource{}
+
+func TestExtractIDs(t *testing.T) {
+	items := []mockResource{
+		{id: "aaa-111"},
+		{id: "bbb-222"},
+		{id: "ccc-333"},
+	}
+	ids := ExtractIDs(items)
+	assert.Equal(t, []string{"aaa-111", "bbb-222", "ccc-333"}, ids)
+}
+
+func TestExtractIDs_Empty(t *testing.T) {
+	ids := ExtractIDs([]mockResource{})
+	assert.Empty(t, ids)
+}
+
+func TestFindByID_Found(t *testing.T) {
+	items := []mockResource{
+		{id: "aaa-111", name: "first"},
+		{id: "bbb-222", name: "second"},
+	}
+	item, found := FindByID(items, "bbb-222")
+	assert.True(t, found)
+	assert.Equal(t, "second", item.name)
+}
+
+func TestFindByID_NotFound(t *testing.T) {
+	items := []mockResource{
+		{id: "aaa-111"},
+	}
+	_, found := FindByID(items, "zzz-999")
+	assert.False(t, found)
+}
+
+func TestFindByID_Empty(t *testing.T) {
+	_, found := FindByID([]mockResource{}, "aaa-111")
+	assert.False(t, found)
+}
+
+func TestListItems(t *testing.T) {
+	list := mockList{
+		items: []mockResource{
+			{id: "aaa-111"},
+			{id: "bbb-222"},
+		},
+	}
+	items := ListItems(list)
+	assert.Len(t, items, 2)
+	assert.Equal(t, "aaa-111", items[0].GetId())
+}
+
+func TestProperties(t *testing.T) {
+	r := mockResource{id: "aaa-111", name: "test-zone"}
+	props := Properties(r)
+	assert.Equal(t, "test-zone", props.Name)
+}

--- a/shared/interfaces_test.go
+++ b/shared/interfaces_test.go
@@ -6,19 +6,17 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// mockResource is a minimal type satisfying Resource, Listable, and HasProperties
-// for testing. It mirrors the shape of generated SDK *Read types.
-type mockResource struct {
+// ptrMockResource mirrors generated SDK types that use pointer receivers
+// for GetId()/GetHref(). All generated SDK *Read types follow this pattern.
+type ptrMockResource struct {
 	id   string
 	href string
-	typ  string
 	name string
 }
 
-func (m mockResource) GetId() string   { return m.id }
-func (m mockResource) GetHref() string { return m.href }
-func (m mockResource) GetType() string { return m.typ }
-func (m mockResource) GetProperties() mockProperties {
+func (m *ptrMockResource) GetId() string   { return m.id }
+func (m *ptrMockResource) GetHref() string { return m.href }
+func (m *ptrMockResource) GetProperties() mockProperties {
 	return mockProperties{Name: m.name}
 }
 
@@ -27,20 +25,20 @@ type mockProperties struct {
 }
 
 type mockList struct {
-	items []mockResource
+	items []ptrMockResource
 }
 
-func (l mockList) GetItems() []mockResource { return l.items }
+func (l mockList) GetItems() []ptrMockResource { return l.items }
 
-// Compile-time interface satisfaction checks
-var _ Identifiable = mockResource{}
-var _ HasHref = mockResource{}
-var _ Resource = mockResource{}
-var _ Listable[mockResource] = mockList{}
-var _ HasProperties[mockProperties] = mockResource{}
+// Compile-time interface satisfaction checks (pointer receivers — matches real SDKs)
+var _ Identifiable = &ptrMockResource{}
+var _ HasHref = &ptrMockResource{}
+var _ Resource = &ptrMockResource{}
+var _ Listable[ptrMockResource] = mockList{}
+var _ HasProperties[mockProperties] = &ptrMockResource{}
 
 func TestExtractIDs(t *testing.T) {
-	items := []mockResource{
+	items := []ptrMockResource{
 		{id: "aaa-111"},
 		{id: "bbb-222"},
 		{id: "ccc-333"},
@@ -50,12 +48,12 @@ func TestExtractIDs(t *testing.T) {
 }
 
 func TestExtractIDs_Empty(t *testing.T) {
-	ids := ExtractIDs([]mockResource{})
+	ids := ExtractIDs([]ptrMockResource{})
 	assert.Empty(t, ids)
 }
 
 func TestFindByID_Found(t *testing.T) {
-	items := []mockResource{
+	items := []ptrMockResource{
 		{id: "aaa-111", name: "first"},
 		{id: "bbb-222", name: "second"},
 	}
@@ -65,32 +63,46 @@ func TestFindByID_Found(t *testing.T) {
 }
 
 func TestFindByID_NotFound(t *testing.T) {
-	items := []mockResource{
+	items := []ptrMockResource{
 		{id: "aaa-111"},
 	}
-	_, found := FindByID(items, "zzz-999")
+	item, found := FindByID(items, "zzz-999")
 	assert.False(t, found)
+	assert.Nil(t, item)
 }
 
 func TestFindByID_Empty(t *testing.T) {
-	_, found := FindByID([]mockResource{}, "aaa-111")
+	item, found := FindByID([]ptrMockResource{}, "aaa-111")
 	assert.False(t, found)
+	assert.Nil(t, item)
+}
+
+func TestFindByID_ReturnsPointerIntoSlice(t *testing.T) {
+	items := []ptrMockResource{
+		{id: "aaa-111", name: "original"},
+	}
+	item, found := FindByID(items, "aaa-111")
+	assert.True(t, found)
+
+	// Mutating via returned pointer should modify the original slice
+	item.name = "mutated"
+	assert.Equal(t, "mutated", items[0].name)
 }
 
 func TestListItems(t *testing.T) {
 	list := mockList{
-		items: []mockResource{
+		items: []ptrMockResource{
 			{id: "aaa-111"},
 			{id: "bbb-222"},
 		},
 	}
 	items := ListItems(list)
 	assert.Len(t, items, 2)
-	assert.Equal(t, "aaa-111", items[0].GetId())
+	assert.Equal(t, "aaa-111", (*ptrMockResource)(&items[0]).GetId())
 }
 
 func TestProperties(t *testing.T) {
-	r := mockResource{id: "aaa-111", name: "test-zone"}
+	r := &ptrMockResource{id: "aaa-111", name: "test-zone"}
 	props := Properties(r)
 	assert.Equal(t, "test-zone", props.Name)
 }

--- a/shared/interfaces_test.go
+++ b/shared/interfaces_test.go
@@ -47,12 +47,12 @@ func TestExtractIDs(t *testing.T) {
 	assert.Equal(t, []string{"aaa-111", "bbb-222", "ccc-333"}, ids)
 }
 
-func TestExtractIDs_Empty(t *testing.T) {
+func TestExtractIDsEmpty(t *testing.T) {
 	ids := ExtractIDs([]ptrMockResource{})
 	assert.Empty(t, ids)
 }
 
-func TestFindByID_Found(t *testing.T) {
+func TestFindByIDFound(t *testing.T) {
 	items := []ptrMockResource{
 		{id: "aaa-111", name: "first"},
 		{id: "bbb-222", name: "second"},
@@ -62,7 +62,7 @@ func TestFindByID_Found(t *testing.T) {
 	assert.Equal(t, "second", item.name)
 }
 
-func TestFindByID_NotFound(t *testing.T) {
+func TestFindByIDNotFound(t *testing.T) {
 	items := []ptrMockResource{
 		{id: "aaa-111"},
 	}
@@ -71,13 +71,13 @@ func TestFindByID_NotFound(t *testing.T) {
 	assert.Nil(t, item)
 }
 
-func TestFindByID_Empty(t *testing.T) {
+func TestFindByIDEmpty(t *testing.T) {
 	item, found := FindByID([]ptrMockResource{}, "aaa-111")
 	assert.False(t, found)
 	assert.Nil(t, item)
 }
 
-func TestFindByID_ReturnsPointerIntoSlice(t *testing.T) {
+func TestFindByIDReturnsPointerIntoSlice(t *testing.T) {
 	items := []ptrMockResource{
 		{id: "aaa-111", name: "original"},
 	}

--- a/shared/resolve.go
+++ b/shared/resolve.go
@@ -10,7 +10,7 @@ var uuidRegex = regexp.MustCompile(
 	`^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$`,
 )
 
-// IsUUID returns true if s is a valid UUID v4 format string.
+// IsUUID returns true if s matches the standard UUID format (any version).
 func IsUUID(s string) bool {
 	return uuidRegex.MatchString(s)
 }

--- a/shared/resolve.go
+++ b/shared/resolve.go
@@ -1,0 +1,60 @@
+package shared
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+)
+
+var uuidRegex = regexp.MustCompile(
+	`^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$`,
+)
+
+// IsUUID returns true if s is a valid UUID v4 format string.
+func IsUUID(s string) bool {
+	return uuidRegex.MatchString(s)
+}
+
+// Resolve resolves a human-readable name to a resource ID.
+//
+// If nameOrID is already a valid UUID, it is returned as-is without
+// making any API calls. Otherwise, listByName is called to find
+// resources matching the given name. Exactly one match is expected;
+// zero matches returns an error, and multiple matches returns an
+// ambiguity error.
+//
+// The listByName callback should call the appropriate SDK list method
+// with a name filter applied and return the matching items.
+//
+// Example usage with the DNS SDK:
+//
+//	id, err := shared.Resolve(ctx, "example.com", func(ctx context.Context, name string) ([]dns.ZoneRead, error) {
+//	    list, _, err := client.ZonesApi.ZonesGet(ctx).FilterZoneName(name).Limit(2).Execute()
+//	    if err != nil {
+//	        return nil, err
+//	    }
+//	    return list.GetItems(), nil
+//	})
+func Resolve[T Identifiable](
+	ctx context.Context,
+	nameOrID string,
+	listByName func(ctx context.Context, name string) ([]T, error),
+) (string, error) {
+	if IsUUID(nameOrID) {
+		return nameOrID, nil
+	}
+
+	items, err := listByName(ctx, nameOrID)
+	if err != nil {
+		return "", fmt.Errorf("resolving %q: %w", nameOrID, err)
+	}
+
+	switch len(items) {
+	case 0:
+		return "", fmt.Errorf("no resource found matching name %q", nameOrID)
+	case 1:
+		return items[0].GetId(), nil
+	default:
+		return "", fmt.Errorf("ambiguous: %d resources match name %q", len(items), nameOrID)
+	}
+}

--- a/shared/resolve.go
+++ b/shared/resolve.go
@@ -16,15 +16,13 @@ func IsUUID(s string) bool {
 }
 
 // Resolve resolves a human-readable name to a resource ID.
+// Works directly with value-type slices returned by SDK list calls.
 //
 // If nameOrID is already a valid UUID, it is returned as-is without
 // making any API calls. Otherwise, listByName is called to find
 // resources matching the given name. Exactly one match is expected;
 // zero matches returns an error, and multiple matches returns an
 // ambiguity error.
-//
-// The listByName callback should call the appropriate SDK list method
-// with a name filter applied and return the matching items.
 //
 // Example usage with the DNS SDK:
 //
@@ -35,7 +33,10 @@ func IsUUID(s string) bool {
 //	    }
 //	    return list.GetItems(), nil
 //	})
-func Resolve[T Identifiable](
+func Resolve[T any, PT interface {
+	*T
+	Identifiable
+}](
 	ctx context.Context,
 	nameOrID string,
 	listByName func(ctx context.Context, name string) ([]T, error),
@@ -53,7 +54,7 @@ func Resolve[T Identifiable](
 	case 0:
 		return "", fmt.Errorf("no resource found matching name %q", nameOrID)
 	case 1:
-		return items[0].GetId(), nil
+		return PT(&items[0]).GetId(), nil
 	default:
 		return "", fmt.Errorf("ambiguous: %d resources match name %q", len(items), nameOrID)
 	}

--- a/shared/resolve_example_test.go
+++ b/shared/resolve_example_test.go
@@ -1,0 +1,42 @@
+package shared_test
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/ionos-cloud/sdk-go-bundle/shared"
+)
+
+func ExampleResolve() {
+	// Simulate: if input is already a UUID, no API call is made.
+	id, _ := shared.Resolve(context.Background(), "550e8400-e29b-41d4-a716-446655440000",
+		func(_ context.Context, _ string) ([]ZoneRead, error) {
+			panic("should not be called")
+		},
+	)
+	fmt.Println("UUID passthrough:", id)
+
+	// Simulate: resolve a zone name to its ID via a list callback.
+	id, _ = shared.Resolve(context.Background(), "example.com",
+		func(_ context.Context, name string) ([]ZoneRead, error) {
+			// In real code this would be:
+			//   list, _, err := client.ZonesApi.ZonesGet(ctx).FilterZoneName(name).Limit(2).Execute()
+			//   return list.GetItems(), err
+			return []ZoneRead{
+				{Id: "550e8400-e29b-41d4-a716-446655440000", Properties: Zone{ZoneName: name}},
+			}, nil
+		},
+	)
+	fmt.Println("Resolved:", id)
+	// Output:
+	// UUID passthrough: 550e8400-e29b-41d4-a716-446655440000
+	// Resolved: 550e8400-e29b-41d4-a716-446655440000
+}
+
+func ExampleIsUUID() {
+	fmt.Println(shared.IsUUID("550e8400-e29b-41d4-a716-446655440000"))
+	fmt.Println(shared.IsUUID("example.com"))
+	// Output:
+	// true
+	// false
+}

--- a/shared/resolve_test.go
+++ b/shared/resolve_test.go
@@ -1,0 +1,88 @@
+package shared
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsUUID(t *testing.T) {
+	tests := []struct {
+		input string
+		want  bool
+	}{
+		{"550e8400-e29b-41d4-a716-446655440000", true},
+		{"550E8400-E29B-41D4-A716-446655440000", true}, // uppercase
+		{"550e8400-e29b-41d4-a716-44665544000", false},  // too short
+		{"example.com", false},
+		{"my-resource", false},
+		{"", false},
+		{"not-a-uuid-at-all-but-has-dashes", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			assert.Equal(t, tt.want, IsUUID(tt.input))
+		})
+	}
+}
+
+func TestResolve_AlreadyUUID(t *testing.T) {
+	uuid := "550e8400-e29b-41d4-a716-446655440000"
+
+	// listByName should never be called when input is a UUID
+	id, err := Resolve(context.Background(), uuid, func(_ context.Context, _ string) ([]mockResource, error) {
+		t.Fatal("listByName should not be called for UUID input")
+		return nil, nil
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, uuid, id)
+}
+
+func TestResolve_SingleMatch(t *testing.T) {
+	id, err := Resolve(context.Background(), "example.com", func(_ context.Context, name string) ([]mockResource, error) {
+		assert.Equal(t, "example.com", name)
+		return []mockResource{
+			{id: "550e8400-e29b-41d4-a716-446655440000", name: "example.com"},
+		}, nil
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, "550e8400-e29b-41d4-a716-446655440000", id)
+}
+
+func TestResolve_NoMatch(t *testing.T) {
+	_, err := Resolve(context.Background(), "nonexistent.com", func(_ context.Context, _ string) ([]mockResource, error) {
+		return []mockResource{}, nil
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no resource found")
+	assert.Contains(t, err.Error(), "nonexistent.com")
+}
+
+func TestResolve_Ambiguous(t *testing.T) {
+	_, err := Resolve(context.Background(), "common-name", func(_ context.Context, _ string) ([]mockResource, error) {
+		return []mockResource{
+			{id: "aaa-bbb-ccc-ddd"},
+			{id: "eee-fff-ggg-hhh"},
+		}, nil
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "ambiguous")
+	assert.Contains(t, err.Error(), "2 resources")
+}
+
+func TestResolve_ListError(t *testing.T) {
+	_, err := Resolve(context.Background(), "example.com", func(_ context.Context, _ string) ([]mockResource, error) {
+		return nil, fmt.Errorf("connection refused")
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "resolving")
+	assert.Contains(t, err.Error(), "connection refused")
+}

--- a/shared/resolve_test.go
+++ b/shared/resolve_test.go
@@ -33,7 +33,7 @@ func TestResolve_AlreadyUUID(t *testing.T) {
 	uuid := "550e8400-e29b-41d4-a716-446655440000"
 
 	// listByName should never be called when input is a UUID
-	id, err := Resolve(context.Background(), uuid, func(_ context.Context, _ string) ([]mockResource, error) {
+	id, err := Resolve(context.Background(), uuid, func(_ context.Context, _ string) ([]ptrMockResource, error) {
 		t.Fatal("listByName should not be called for UUID input")
 		return nil, nil
 	})
@@ -43,9 +43,9 @@ func TestResolve_AlreadyUUID(t *testing.T) {
 }
 
 func TestResolve_SingleMatch(t *testing.T) {
-	id, err := Resolve(context.Background(), "example.com", func(_ context.Context, name string) ([]mockResource, error) {
+	id, err := Resolve(context.Background(), "example.com", func(_ context.Context, name string) ([]ptrMockResource, error) {
 		assert.Equal(t, "example.com", name)
-		return []mockResource{
+		return []ptrMockResource{
 			{id: "550e8400-e29b-41d4-a716-446655440000", name: "example.com"},
 		}, nil
 	})
@@ -55,8 +55,8 @@ func TestResolve_SingleMatch(t *testing.T) {
 }
 
 func TestResolve_NoMatch(t *testing.T) {
-	_, err := Resolve(context.Background(), "nonexistent.com", func(_ context.Context, _ string) ([]mockResource, error) {
-		return []mockResource{}, nil
+	_, err := Resolve(context.Background(), "nonexistent.com", func(_ context.Context, _ string) ([]ptrMockResource, error) {
+		return []ptrMockResource{}, nil
 	})
 
 	require.Error(t, err)
@@ -65,8 +65,8 @@ func TestResolve_NoMatch(t *testing.T) {
 }
 
 func TestResolve_Ambiguous(t *testing.T) {
-	_, err := Resolve(context.Background(), "common-name", func(_ context.Context, _ string) ([]mockResource, error) {
-		return []mockResource{
+	_, err := Resolve(context.Background(), "common-name", func(_ context.Context, _ string) ([]ptrMockResource, error) {
+		return []ptrMockResource{
 			{id: "aaa-bbb-ccc-ddd"},
 			{id: "eee-fff-ggg-hhh"},
 		}, nil
@@ -78,7 +78,7 @@ func TestResolve_Ambiguous(t *testing.T) {
 }
 
 func TestResolve_ListError(t *testing.T) {
-	_, err := Resolve(context.Background(), "example.com", func(_ context.Context, _ string) ([]mockResource, error) {
+	_, err := Resolve(context.Background(), "example.com", func(_ context.Context, _ string) ([]ptrMockResource, error) {
 		return nil, fmt.Errorf("connection refused")
 	})
 

--- a/shared/resolve_test.go
+++ b/shared/resolve_test.go
@@ -29,7 +29,7 @@ func TestIsUUID(t *testing.T) {
 	}
 }
 
-func TestResolve_AlreadyUUID(t *testing.T) {
+func TestResolveAlreadyUUID(t *testing.T) {
 	uuid := "550e8400-e29b-41d4-a716-446655440000"
 
 	// listByName should never be called when input is a UUID
@@ -42,7 +42,7 @@ func TestResolve_AlreadyUUID(t *testing.T) {
 	assert.Equal(t, uuid, id)
 }
 
-func TestResolve_SingleMatch(t *testing.T) {
+func TestResolveSingleMatch(t *testing.T) {
 	id, err := Resolve(context.Background(), "example.com", func(_ context.Context, name string) ([]ptrMockResource, error) {
 		assert.Equal(t, "example.com", name)
 		return []ptrMockResource{
@@ -54,7 +54,7 @@ func TestResolve_SingleMatch(t *testing.T) {
 	assert.Equal(t, "550e8400-e29b-41d4-a716-446655440000", id)
 }
 
-func TestResolve_NoMatch(t *testing.T) {
+func TestResolveNoMatch(t *testing.T) {
 	_, err := Resolve(context.Background(), "nonexistent.com", func(_ context.Context, _ string) ([]ptrMockResource, error) {
 		return []ptrMockResource{}, nil
 	})
@@ -64,7 +64,7 @@ func TestResolve_NoMatch(t *testing.T) {
 	assert.Contains(t, err.Error(), "nonexistent.com")
 }
 
-func TestResolve_Ambiguous(t *testing.T) {
+func TestResolveAmbiguous(t *testing.T) {
 	_, err := Resolve(context.Background(), "common-name", func(_ context.Context, _ string) ([]ptrMockResource, error) {
 		return []ptrMockResource{
 			{id: "aaa-bbb-ccc-ddd"},
@@ -77,7 +77,7 @@ func TestResolve_Ambiguous(t *testing.T) {
 	assert.Contains(t, err.Error(), "2 resources")
 }
 
-func TestResolve_ListError(t *testing.T) {
+func TestResolveListError(t *testing.T) {
 	_, err := Resolve(context.Background(), "example.com", func(_ context.Context, _ string) ([]ptrMockResource, error) {
 		return nil, fmt.Errorf("connection refused")
 	})


### PR DESCRIPTION
  - Add generic Go interfaces (Identifiable, HasHref, Resource, Listable[T], HasProperties[P]) that abstract the common accessor patterns across all generated SDK model types
  - Add Resolve() — a generic helper that accepts a name or UUID and resolves it to a resource ID via a caller-supplied list callback, with clear errors for zero/ambiguous matches
  - Add CI workflow for the shared/ package (tests with race detector + coverage)
  - Add testable examples that appear in godoc and validate usage with DNS-like types


Example:

```go
  // Different SDK types (zones, records, or any product) satisfy the same
  // interfaces — they can be combined and operated on uniformly.
  var all []shared.Resource
  for i := range zones {
      all = append(all, &zones[i])   // *dns.ZoneRead satisfies shared.Resource
  }
  for i := range records {
      all = append(all, &records[i]) // *dns.RecordRead satisfies shared.Resource
  }
  for _, r := range all {
      fmt.Println(r.GetId(), r.GetHref()) // works on both types
  }

  // Find a specific resource by ID.
  zone, ok := shared.FindByID(all.GetItems(), "550e8400-e29b-41d4-a716-446655440000")
  if ok {
      fmt.Println(zone.GetProperties().GetZoneName())
  }

  // Resolve a name-or-UUID to an ID. If already a UUID, no API call is made.
  id, err := shared.Resolve(ctx, "example.com", func(ctx context.Context, name string) ([]dns.ZoneRead, error) {
      result, _, err := client.ZonesApi.ZonesGet(ctx).FilterZoneName(name).Limit(2).Execute()
      if err != nil {
          return nil, err
      }
      return result.GetItems(), nil
  })

```