### PR TITLE
chore: align brand references to IONOS CLOUD

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: false
 contact_links:
-  - name: IONOS Cloud API
+  - name: IONOS CLOUD API
     url: https://devops.ionos.com/api/
     about: View API documentation

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # sdk-go-bundle
-Enables users of IONOS Cloud sdks to use one repo for all the GO SDKs released.
+Enables users of IONOS CLOUD sdks to use one repo for all the GO SDKs released.
 
 # Go API client for ionoscloud
 
@@ -8,15 +8,15 @@ IONOS Enterprise-grade Infrastructure as a Service (IaaS) solutions can be manag
 Both methods employ consistent concepts and features, deliver similar power and flexibility, and can be used to perform a multitude of management tasks, including adding servers, volumes, configuring networks, and so on.
 
 ## Overview
-The IONOS Cloud SDK for GO bundle provides you with access to the IONOS Cloud API. The client library supports both simple and complex requests.
-It is designed for developers who are building applications in GO . The SDK for GO wraps the IONOS Cloud API. All API operations are performed over SSL and authenticated using your IONOS Cloud portal credentials.
-The API can be accessed within an instance running in IONOS Cloud or directly over the Internet from any application that can send an HTTPS request and receive an HTTPS response.
+The IONOS CLOUD SDK for GO bundle provides you with access to the IONOS CLOUD API. The client library supports both simple and complex requests.
+It is designed for developers who are building applications in GO . The SDK for GO wraps the IONOS CLOUD API. All API operations are performed over SSL and authenticated using your IONOS CLOUD portal credentials.
+The API can be accessed within an instance running in IONOS CLOUD or directly over the Internet from any application that can send an HTTPS request and receive an HTTPS response.
 
 ## List of all SDK products in `sdk-go-bundle`, along with their equivalents in the separate repos
 
 | SDK Name    | Sdk-go-bundle module                             | Full repo equivalent                                               | Description                                                                                                                                                                                                                                                                                                                                                                       |
 |-------------|--------------------------------------------------|--------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| Authentication | [readme](./products/auth/README.md)              | [readme](https://github.com/ionos-cloud/sdk-go-auth)               | Use the Auth API to manage tokens for secure access to IONOS Cloud  APIs (Auth API, Cloud API, Reseller API, Activity Log API, and others).                                                                                                                                                                                                                                       |
+| Authentication | [readme](./products/auth/README.md)              | [readme](https://github.com/ionos-cloud/sdk-go-auth)               | Use the Auth API to manage tokens for secure access to IONOS CLOUD  APIs (Auth API, Cloud API, Reseller API, Activity Log API, and others).                                                                                                                                                                                                                                       |
 | Compute     | [readme](./products/compute/README.md)           | [readme](https://github.com/ionos-cloud/sdk-go)                    | Use the Auth API to manage resources in the compute engine: datacenters, locations, servers, kubernetes resources, images, volumes, lans, ip blocks, network interfaces, private cross connects, firewall rules, flow logs, load balancers, nat gateways, network load balancers, application load balancers, target groups, s3 keys, snapshots, users, groups, labels, templates |
 | DBaaS Mongo | [readme](./products/dbaas/mongo/README.md)       | [readme](https://github.com/ionos-cloud/sdk-go-dbaas-mongo)        | You have the ability to quickly set up and manage a MongoDB database. You can also delete clusters, manage backups and users via the API. The MongoDB API allows you to create additional database clusters or modify existing ones.                                                                                                                                              |
 | DBaaS Postgres SQL | [readme](./products/dbaas/psql/README.md)        | [readme](https://github.com/ionos-cloud/sdk-go-dbaas-postgres)     | The API allows you to create additional PostgreSQL database clusters or modify existing ones.                                                                                                                                                                                                                                                                                     |
@@ -29,8 +29,8 @@ The API can be accessed within an instance running in IONOS Cloud or directly ov
 
 | Environment Variable | Description                                                                                                                                                                                                                                 |
 |----------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `IONOS_USERNAME`     | Specify the username used to login, to authenticate against the IONOS Cloud API                                                                                                                                                             |
-| `IONOS_PASSWORD`     | Specify the password used to login, to authenticate against the IONOS Cloud API                                                                                                                                                             |
+| `IONOS_USERNAME`     | Specify the username used to login, to authenticate against the IONOS CLOUD API                                                                                                                                                             |
+| `IONOS_PASSWORD`     | Specify the password used to login, to authenticate against the IONOS CLOUD API                                                                                                                                                             |
 | `IONOS_TOKEN`        | Specify the token used to login, if a token is being used instead of username and password                                                                                                                                                  |
 | `IONOS_API_URL`      | Specify the API URL. It will overwrite the API endpoint default value `api.ionos.com`. Note: for compute, the host URL does not contain the `/cloudapi/v6` path, so it should _not_ be included in the `IONOS_API_URL` environment variable |
 | `IONOS_LOG_LEVEL`    | Specify the Log Level used to log messages. Possible values: Off, Debug, Trace                                                                                                                                                              |
@@ -41,7 +41,7 @@ The API can be accessed within an instance running in IONOS Cloud or directly ov
 ## Getting started
 
 To start working with the SDK, set up your project for Go modules, and retrieve the SDK dependencies with `go get`. This example shows how to use the SDK
-to make an API request to IONOS Cloud.
+to make an API request to IONOS CLOUD.
 
 ### Create directory
 


### PR DESCRIPTION
## Scope
Aligns hand-written README and issue-template prose to the brand form IONOS CLOUD (all caps).

## Excluded by design
Generated product godoc headers under products/** are intentionally not changed here. They originate from upstream templates and align on regeneration via the sdk-resources templates.

## Out of scope (unchanged)
Package paths, environment variable names, generated code, and vendored dependencies are left untouched.

## Verification
After the change, a repo scan for the old form in README.md and .github/ returns zero matches, and git status lists only the two edited files.